### PR TITLE
Issue build on macos and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cmd/main/application.log
 release/
 go-c8y-cli-microservice*
 input.list
+bin/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ The `~/.cumulocity` folder (created by go-c8y-cli) is mounted from your host OS 
 
 3. When prompted by VScode, rebuild/reopen the project in the dev container. Be patient, it needs to build a docker image.
 
+    If you do not want to open the project in a dev container, then you must install [go-task](https://taskfile.dev/installation/) using the following procedure:
+
+    ```sh
+    env GOBIN="$(pwd)/bin" go install github.com/go-task/task/v3/cmd/task@latest
+    export PATH=$(cd bin && pwd):$PATH
+
+    # alternative you can call the locally installed task version using:
+    bin/task init
+    bin/task build:microservice
+    bin/task deploy:microservice
+    ```
+
 4. Activate/Create a Cumulocity session pointing to the Cumulocity instance you want to develop against
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ c8y api POST "/service/go-c8y-cli-microservice/commands/importevents/sync" --for
 ```
 
 ```
-sudo docker run -it --env-file=.env go-c8y-cli-microservice:0.0.1 bash
+sudo docker run -it --env-file=.env go-c8y-cli-microservice:0.0.2 bash
 ```
 
 ## Execute command

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Build the Cumulocity microservice zip file by executing
 task build:microservice
 ```
 
+**Notes**
+
+* It is assumed that the user running the command is able to run docker commands without using sudo. If your user does not have the correct permissions, then you may have some success using the following 
+
+    ```
+    sudo -E task build:microservice
+    ```
+
 ## Deploy
 
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -80,7 +80,7 @@ tasks:
     desc: Build the microservice artifact that can be uploaded to Cumulocity
     cmds:
       - chmod +x ./build/microservice.sh
-      - sudo bash -e ./build/microservice.sh pack --directory ./ --name {{.BINARY_NAME}} --tag "{{.VERSION_TAG}}"
+      - bash -e ./build/microservice.sh pack --directory ./ --name {{.BINARY_NAME}} --tag "{{.VERSION_TAG}}"
       - mkdir -p {{.RELEASE_DIR}}
       - mv -f {{.BINARY_NAME}}.zip {{.RELEASE_DIR}}/{{.BINARY_NAME}}-v{{.VERSION_TAG}}.zip
 

--- a/build/microservice.sh
+++ b/build/microservice.sh
@@ -9,6 +9,7 @@ DEPLOY_USER=
 DEPLOY_PASSWORD=
 APPLICATION_NAME=
 APPLICATION_ID=
+PLATFORM="linux/amd64"
 
 PACK=1
 DEPLOY=1
@@ -199,7 +200,7 @@ clearTarget () {
 buildImage () {
 	cd "$DOCKERFILE_FOLDER"
 	echo "[INFO] Build image $IMAGE_NAME:$TAG_NAME"
-	docker build --build-arg HTTP_PROXY=$HTTP_PROXY --build-arg HTTPS_PROXY=$HTTPS_PROXY --build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY -t $IMAGE_NAME:$TAG_NAME .
+	docker build --build-arg HTTP_PROXY=$HTTP_PROXY --build-arg HTTPS_PROXY=$HTTPS_PROXY --build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY -t $IMAGE_NAME:$TAG_NAME --platform $PLATFORM .
 }
 
 exportImage () {

--- a/cumulocity.json
+++ b/cumulocity.json
@@ -1,6 +1,6 @@
 {
   "apiVersion": "1",
-  "version": "0.0.1-SNAPSHOT",
+  "version": "0.0.2-SNAPSHOT",
   "provider": {
     "name": "Example Company"
   },


### PR DESCRIPTION
* Removed sudo requirements when building the microservice and added note about how to run it if sudo is required
* Add notes about running the tasks (init/build/deploy) when the project has not been opened in the dev container
* bump version to 0.0.2